### PR TITLE
BboltPlugin.java: Prevent creating more than 1 db

### DIFF
--- a/android/src/main/java/com/pakupakis/bbolt/BboltPlugin.java
+++ b/android/src/main/java/com/pakupakis/bbolt/BboltPlugin.java
@@ -15,6 +15,8 @@ import mobile.BoltDB;
 /** BboltPlugin */
 public class BboltPlugin implements MethodCallHandler {
   private static BoltDB db;
+  static boolean created = false;
+
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
@@ -22,7 +24,10 @@ public class BboltPlugin implements MethodCallHandler {
     channel.setMethodCallHandler(new BboltPlugin());
 
     File appFiles = registrar.activeContext().getFilesDir();
-    db = new BoltDB(appFiles.getAbsolutePath());
+    if(!created){
+      db = new BoltDB(appFiles.getAbsolutePath());
+      created = true;
+    }
   }
 
   @Override


### PR DESCRIPTION
This should prevent the crashing when with Image-picker package